### PR TITLE
replace the floating‑point sqrt and type conversion with isqrt

### DIFF
--- a/fields/src/macros.rs
+++ b/fields/src/macros.rs
@@ -95,7 +95,7 @@ macro_rules! sqrt_impl {
                 let v = $self.pow($P::T_MINUS_ONE_DIV_TWO);
                 let x = *$self * v.square();
 
-                let k = ((n - 1) as f64).sqrt().floor() as u64;
+                let k = n.isqrt();
                 // It's important that k_2 results in a number which makes `l_minus_one_times_k`
                 // divisible by `k`, because the native arithmetic will not match the field
                 // arithmetic otherwise (native numbers will divide and round down, but field


### PR DESCRIPTION
Removing floating‑point operations from the codebase. This is necessary to move forward with compiling snarkVM for CosmWasm.